### PR TITLE
Segger integration branch to v6.9.3 main qpcpp repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ QSpy/
 lib/
 obj/
 output/
+
+.DS_Store


### PR DESCRIPTION
Only GIT Ignore has changed.